### PR TITLE
Channels

### DIFF
--- a/priv/repo/migrations/20161014151946_create_annotation.exs
+++ b/priv/repo/migrations/20161014151946_create_annotation.exs
@@ -1,0 +1,17 @@
+defmodule Rumbl.Repo.Migrations.CreateAnnotation do
+  use Ecto.Migration
+
+  def change do
+    create table(:annotations) do
+      add :body, :text
+      add :at, :integer
+      add :user_id, references(:users, on_delete: :nothing)
+      add :video_id, references(:videos, on_delete: :nothing)
+
+      timestamps()
+    end
+    create index(:annotations, [:user_id])
+    create index(:annotations, [:video_id])
+
+  end
+end

--- a/test/models/annotation_test.exs
+++ b/test/models/annotation_test.exs
@@ -1,0 +1,18 @@
+defmodule Rumbl.AnnotationTest do
+  use Rumbl.ModelCase
+
+  alias Rumbl.Annotation
+
+  @valid_attrs %{at: 42, body: "some content"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = Annotation.changeset(%Annotation{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = Annotation.changeset(%Annotation{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/web/channels/user_socket.ex
+++ b/web/channels/user_socket.ex
@@ -10,6 +10,9 @@ defmodule Rumbl.UserSocket do
   transport :websocket, Phoenix.Transports.WebSocket
   # transport :longpoll, Phoenix.Transports.LongPoll
 
+  # 2 weeks
+  @max_age 2 * 7 * 24 * 60 * 60
+
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After
   # verification, you can put default assigns into
@@ -21,9 +24,16 @@ defmodule Rumbl.UserSocket do
   #
   # See `Phoenix.Token` documentation for examples in
   # performing token verification on connect.
-  def connect(_params, socket) do
-    {:ok, socket}
+  def connect(%{"token" => token}, socket) do
+    case Phoenix.Token.verify(socket, "user socket", token, max_age: @max_age) do
+      {:ok, user_id} ->
+        {:ok, assign(socket, :user_id, user_id)}
+      {:error, _reason} ->
+        :error
+    end
   end
+
+  def connect(_params, _socket), do: :error
 
   # Socket id's are topics that allow you to identify all sockets for a given user:
   #
@@ -35,5 +45,5 @@ defmodule Rumbl.UserSocket do
   #     Rumbl.Endpoint.broadcast("users_socket:#{user.id}", "disconnect", %{})
   #
   # Returning `nil` makes this socket anonymous.
-  def id(_socket), do: nil
+  def id(socket), do: "user_socket:#{socket.assigns.user_id}"
 end

--- a/web/channels/user_socket.ex
+++ b/web/channels/user_socket.ex
@@ -3,6 +3,8 @@ defmodule Rumbl.UserSocket do
 
   ## Channels
   # channel "room:*", Rumbl.RoomChannel
+  # categorizes topics with a resource name followed by resource ID.
+  channel "videos:*", Rumbl.VideoChannel
 
   ## Transports
   transport :websocket, Phoenix.Transports.WebSocket

--- a/web/channels/video_channel.ex
+++ b/web/channels/video_channel.ex
@@ -1,0 +1,11 @@
+defmodule Rumbl.VideoChannel do
+  use Rumbl.Web, :channel
+
+  # Clients can join topics on a channel
+  # Return {:ok, socket} to authorize a join attempt or {:error, socket} to deny one.
+  #
+  # Add video ID from topic to socket.assigns, which typically holds a map.
+  def join("videos:" <> video_id, _params, socket) do
+    {:ok, assign(socket, :video_id, String.to_integer(video_id))}
+  end
+end

--- a/web/channels/video_channel.ex
+++ b/web/channels/video_channel.ex
@@ -3,27 +3,25 @@ defmodule Rumbl.VideoChannel do
 
   # Clients can join topics on a channel
   # Return {:ok, socket} to authorize a join attempt or {:error, socket} to deny one.
-  #
-  # Add video ID from topic to socket.assigns, which typically holds a map.
   def join("videos:" <> video_id, _params, socket) do
-    :timer.send_interval(5_000, :ping)
-    {:ok, assign(socket, :video_id, String.to_integer(video_id))}
+    {:ok, socket}
   end
 
-  # callback for receiving direct channel events.
-  # invoked whenever an elixir message reaches the channel.
-  # match on :ping and increment counter when it arrives.
-  # Takes a socket and returns a transformed socket.
-  def handle_info(:ping, socket) do
-    count = socket.assigns[:count] || 1
+  # handles all incoming messages to the channel pushed from the remote client.
+  # not persisting to the database yet, so just broadcast new_annotation events
+  # to all clients on this topic.
+  def handle_in("new_annotation", params, socket) do
+    # the payload is an arbitrary map.
+    # we can send as many messages as we like.
+    # DO NOT forward along the raw payload.
+    broadcast! socket, "new_annotation", %{
+      user: %{username: "anon"},
+      body: params["body"],
+      at: params["at"]
+    }
 
-    # push the ping event, picked up by client with the
-    # channel.on(event, callback) API. See video.js.
-    push socket, "ping", %{count: count}
-
-    # return tagged tuple.
-    # :noreply means not sending a reply, assign function transforms
-    # the socket by adding the new count
-    {:noreply, assign(socket, :count, count + 1)}
+    # sends reply back to the client with status and socket
+    # can also use :noreply
+    {:reply, :ok, socket}
   end
 end

--- a/web/channels/video_channel.ex
+++ b/web/channels/video_channel.ex
@@ -6,6 +6,24 @@ defmodule Rumbl.VideoChannel do
   #
   # Add video ID from topic to socket.assigns, which typically holds a map.
   def join("videos:" <> video_id, _params, socket) do
+    :timer.send_interval(5_000, :ping)
     {:ok, assign(socket, :video_id, String.to_integer(video_id))}
+  end
+
+  # callback for receiving direct channel events.
+  # invoked whenever an elixir message reaches the channel.
+  # match on :ping and increment counter when it arrives.
+  # Takes a socket and returns a transformed socket.
+  def handle_info(:ping, socket) do
+    count = socket.assigns[:count] || 1
+
+    # push the ping event, picked up by client with the
+    # channel.on(event, callback) API. See video.js.
+    push socket, "ping", %{count: count}
+
+    # return tagged tuple.
+    # :noreply means not sending a reply, assign function transforms
+    # the socket by adding the new count
+    {:noreply, assign(socket, :count, count + 1)}
   end
 end

--- a/web/channels/video_channel.ex
+++ b/web/channels/video_channel.ex
@@ -4,24 +4,44 @@ defmodule Rumbl.VideoChannel do
   # Clients can join topics on a channel
   # Return {:ok, socket} to authorize a join attempt or {:error, socket} to deny one.
   def join("videos:" <> video_id, _params, socket) do
-    {:ok, socket}
+    {:ok, assign(socket, :video_id, String.to_integer(video_id))}
+  end
+
+  # Ensure all incoming events have the current user.
+  def handle_in(event, params, socket) do
+    user = Repo.get(Rumbl.User, socket.assigns.user_id)
+    handle_in(event, params, user, socket)
   end
 
   # handles all incoming messages to the channel pushed from the remote client.
-  # not persisting to the database yet, so just broadcast new_annotation events
-  # to all clients on this topic.
-  def handle_in("new_annotation", params, socket) do
-    # the payload is an arbitrary map.
-    # we can send as many messages as we like.
-    # DO NOT forward along the raw payload.
-    broadcast! socket, "new_annotation", %{
-      user: %{username: "anon"},
-      body: params["body"],
-      at: params["at"]
-    }
+  def handle_in("new_annotation", params, user, socket) do
+    changeset =
+      user
+      |> build_assoc(:annotations, video_id: socket.assigns.video_id)
+      |> Rumbl.Annotation.changeset(params)
 
-    # sends reply back to the client with status and socket
-    # can also use :noreply
-    {:reply, :ok, socket}
+    case Repo.insert(changeset) do
+      {:ok, annotation} ->
+        # the payload is an arbitrary map.
+        # we can send as many messages as we like.
+        # DO NOT forward along the raw payload.
+        broadcast! socket, "new_annotation", %{
+          id: annotation.id,
+          user: Rumbl.UserView.render("user.json", %{user: user}),
+          body: annotation.body,
+          at: annotation.at
+        }
+
+        # sends reply back to the client with status and socket
+        # can also use :noreply, but it's common practice to acknowledge the
+        # result of the pushed message from the client.
+        # This allows clients to implement UI features like loading statuses
+        # and error notifications.
+        {:reply, :ok, socket}
+
+      {:error, changeset} ->
+        {:reply, {:error, %{errors: changeset}}, socket}
+    end
+
   end
 end

--- a/web/models/annotation.ex
+++ b/web/models/annotation.ex
@@ -1,0 +1,21 @@
+defmodule Rumbl.Annotation do
+  use Rumbl.Web, :model
+
+  schema "annotations" do
+    field :body, :string
+    field :at, :integer
+    belongs_to :user, Rumbl.User
+    belongs_to :video, Rumbl.Video
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:body, :at])
+    |> validate_required([:body, :at])
+  end
+end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -7,6 +7,7 @@ defmodule Rumbl.User do
     field :password, :string, virtual: true
     field :password_hash, :string
     has_many :videos, Rumbl.Video
+    has_many :annotations, Rumbl.Annotation
     timestamps
   end
 

--- a/web/models/video.ex
+++ b/web/models/video.ex
@@ -12,6 +12,7 @@ defmodule Rumbl.Video do
     field :slug, :string
     belongs_to :user, Rumbl.User
     belongs_to :category, Rumbl.Category
+    has_many :annotations, Rumbl.Annotation
 
     timestamps()
   end

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -18,13 +18,8 @@ import "phoenix_html"
 // Local files can be imported directly using relative
 // paths "./socket" or full ones "web/static/js/socket".
 
-// import socket from "./socket"
+import socket from "./socket"
+import Video from "./video"
 
-import Player from "./player"
-let video = document.getElementById("video")
-
-if(video) {
-  Player.init(video.id, video.getAttribute("data-player-id"), () => {
-    console.log("player ready!")
-  })
-}
+// Initialization now done in video.js instead of player.js
+Video.init(socket, document.getElementById("video"))

--- a/web/static/js/socket.js
+++ b/web/static/js/socket.js
@@ -5,7 +5,10 @@
 // and connect at the socket path in "lib/my_app/endpoint.ex":
 import {Socket} from "phoenix"
 
-let socket = new Socket("/socket", {params: {token: window.userToken}})
+let socket = new Socket("/socket", {
+  params: {token: window.userToken},
+  logger: (kind, msg, data) => { console.log(`${kind}: ${msg}`, data) }
+})
 
 // When you connect, you'll often need to authenticate the client.
 // For example, imagine you have an authentication plug, `MyAuth`,
@@ -51,12 +54,12 @@ let socket = new Socket("/socket", {params: {token: window.userToken}})
 // Finally, pass the token on connect as below. Or remove it
 // from connect if you don't care about authentication.
 
-socket.connect()
+// socket.connect()
 
 // Now that you are connected, you can join channels with a topic:
-let channel = socket.channel("topic:subtopic", {})
-channel.join()
-  .receive("ok", resp => { console.log("Joined successfully", resp) })
-  .receive("error", resp => { console.log("Unable to join", resp) })
+//let channel = socket.channel("topic:subtopic", {})
+//channel.join()
+//  .receive("ok", resp => { console.log("Joined successfully", resp) })
+//  .receive("error", resp => { console.log("Unable to join", resp) })
 
 export default socket

--- a/web/static/js/socket.js
+++ b/web/static/js/socket.js
@@ -5,6 +5,8 @@
 // and connect at the socket path in "lib/my_app/endpoint.ex":
 import {Socket} from "phoenix"
 
+// params passed to the socker constructor will be available as the first
+// argument in UserSocket.connect
 let socket = new Socket("/socket", {
   params: {token: window.userToken},
   logger: (kind, msg, data) => { console.log(`${kind}: ${msg}`, data) }

--- a/web/static/js/video.js
+++ b/web/static/js/video.js
@@ -43,7 +43,10 @@ let Video = {
 
     // create a new channel object from our socket and give it a topic
     vidChannel.join()
-      .receive("ok", resp => console.log("joined the video channel", resp) )
+      .receive("ok", ({annotations}) => {
+        // pick up join response from server with the annotations in the db.
+        annotations.forEach( ann => this.renderAnnotation(msgContainer, ann) )
+      })
       .receive("error", reason => console.log("join failed", reason) )
   },
 

--- a/web/static/js/video.js
+++ b/web/static/js/video.js
@@ -23,12 +23,48 @@ let Video = {
     // this will be used to connect ES6 client to Phoenix VideoChannel
     // convention for topic identifiers
     let vidChannel = socket.channel("videos:" + videoId)
-    vidChannel.on("ping", ({count}) => console.log("PING", count) )
+
+    // Handle click event on the post button.
+    // push function on vidChannel sends contents of message to server.
+    // then clear the input control.
+    postButton.addEventListener("click", e => {
+      let payload = {body: msgInput.value, at: Player.getCurrentTime()}
+      // when we push a message to the server, we can opt to receive a response
+      vidChannel.push("new_annotation", payload)
+                .receive("error", e => console.log(e) )
+      msgInput.value = ""
+    })
+
+    // when users post new annotations, the server will broadcast the event to
+    // the clients. This handles the event.
+    vidChannel.on("new_annotation", (resp) => {
+      this.renderAnnotation(msgContainer, resp)
+    })
 
     // create a new channel object from our socket and give it a topic
     vidChannel.join()
       .receive("ok", resp => console.log("joined the video channel", resp) )
       .receive("error", reason => console.log("join failed", reason) )
+  },
+
+  // escape user input before injecting values into the page.
+  esc(str){
+    let div = document.createElement("div")
+    div.appendChild(document.createTextNode(str))
+    return div.innerHTML
+  },
+
+  renderAnnotation(msgContainer, {user, body, at}){
+    // build a DOM node with the user's name and annotation body
+    let template = document.createElement("div")
+    template.innerHTML = `
+    <a href="#" data-seek="${this.esc(at)}">
+      <b>${this.esc(user.username)}</b>: ${this.esc(body)}
+    </a>
+     `
+    // append it to the msgContainer list and scroll to the right point.
+    msgContainer.appendChild(template)
+    msgContainer.scrollTop = msgContainer.scrollHeight
   }
 }
 export default Video

--- a/web/static/js/video.js
+++ b/web/static/js/video.js
@@ -46,12 +46,20 @@ let Video = {
     // when users post new annotations, the server will broadcast the event to
     // the clients. This handles the event.
     vidChannel.on("new_annotation", (resp) => {
+      // channel on the client holds a params object and sends it to the server
+      // every time we call channel.join()
+      // modify this object to store the last_seen_id when new_annotation event
+      // is received.
+      vidChannel.params.last_seen_id = resp.id
       this.renderAnnotation(msgContainer, resp)
     })
 
     // create a new channel object from our socket and give it a topic
     vidChannel.join()
       .receive("ok", resp => {
+        // store the max annotation ID as the last seen ID
+        let ids = resp.annotations.map(ann => ann.id)
+        if(ids.length > 0){ vidChannel.params.last_seen_id = Math.max(...ids) }
         // schedule annotations to render based on current player time,
         // instead of rendering all of them on join.
         this.scheduleMessages(msgContainer, resp.annotations)

--- a/web/static/js/video.js
+++ b/web/static/js/video.js
@@ -1,0 +1,29 @@
+import Player from "./player"
+
+let Video = {
+  init(socket, element){ if(!element){ return }
+    // setup the player and pluck the video ID from the element attributes
+    let playerId = element.getAttribute("data-player-id")
+    let videoId = element.getAttribute("data-id")
+    // start the socket connection
+    socket.connect()
+    Player.init(element.id, playerId, () => {
+      // initialize player with callback when player has loaded
+      this.onReady(videoId, socket)
+    })
+  },
+
+  onReady(videoId, socket){
+    // container for annotations
+    let msgContainer = document.getElementById("msg-container")
+    // the input control
+    let msgInput = document.getElementById("msg-input")
+    // button for creating a new annotation
+    let postButton = document.getElementById("msg-submit")
+    // this will be used to connect ES6 client to Phoenix VideoChannel
+    // convention for topic identifiers
+    let vidChannel = socket.channel("videos:" + videoId)
+    // TODO join the vidChannel
+  }
+}
+export default Video

--- a/web/static/js/video.js
+++ b/web/static/js/video.js
@@ -23,7 +23,11 @@ let Video = {
     // this will be used to connect ES6 client to Phoenix VideoChannel
     // convention for topic identifiers
     let vidChannel = socket.channel("videos:" + videoId)
-    // TODO join the vidChannel
+
+    // create a new channel object from our socket and give it a topic
+    vidChannel.join()
+      .receive("ok", resp => console.log("joined the video channel", resp) )
+      .receive("error", reason => console.log("join failed", reason) )
   }
 }
 export default Video

--- a/web/static/js/video.js
+++ b/web/static/js/video.js
@@ -35,6 +35,14 @@ let Video = {
       msgInput.value = ""
     })
 
+    msgContainer.addEventListener("click", e => {
+      e.preventDefault()
+      let seconds = e.target.getAttribute("data-seek") ||
+                    e.target.parentNode.getAttribute("data-seek")
+      if(!seconds){ return }
+      Player.seekTo(seconds)
+    })
+
     // when users post new annotations, the server will broadcast the event to
     // the clients. This handles the event.
     vidChannel.on("new_annotation", (resp) => {

--- a/web/static/js/video.js
+++ b/web/static/js/video.js
@@ -23,6 +23,7 @@ let Video = {
     // this will be used to connect ES6 client to Phoenix VideoChannel
     // convention for topic identifiers
     let vidChannel = socket.channel("videos:" + videoId)
+    vidChannel.on("ping", ({count}) => console.log("PING", count) )
 
     // create a new channel object from our socket and give it a topic
     vidChannel.join()

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -45,6 +45,7 @@
       </main>
 
     </div> <!-- /container -->
+    <script>window.userToken = "<%= assigns[:user_token] %>"</script>
     <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
   </body>
 </html>

--- a/web/views/annotation_view.ex
+++ b/web/views/annotation_view.ex
@@ -1,0 +1,12 @@
+defmodule Rumbl.AnnotationView do
+  use Rumbl.Web, :view
+
+  def render("annotation.json", %{annotation: ann}) do
+    %{
+      id: ann.id,
+      body: ann.body,
+      at: ann.at,
+      user: render_one(ann.user, Rumbl.UserView, "user.json")
+    }
+  end
+end

--- a/web/views/user_view.ex
+++ b/web/views/user_view.ex
@@ -7,4 +7,8 @@ defmodule Rumbl.UserView do
     |> String.split(" ")
     |> Enum.at(0)
   end
+
+  def render("user.json", %{user: user}) do
+    %{id: user.id, username: user.username}
+  end
 end


### PR DESCRIPTION
Use channels to allow clients to add annotations to the video and have them broadcast to other clients watching the same video.

Authenticate the clients with `Phoenix.Token`.

Persist the annotations in the database.

Sync annotations with the video playback time.

Handle disconnects so annotations don't show up multiple times when the client has to reconnect to the server.
